### PR TITLE
Add Colors and Change fix the Height of the Editors that were too big

### DIFF
--- a/SymptomTracker/Page/CreateEventPage.xaml
+++ b/SymptomTracker/Page/CreateEventPage.xaml
@@ -3,7 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="SymptomTracker.Page.CreateEventPage"
              xmlns:conv="clr-namespace:SymptomTracker.Converter"
-             Title="{Binding ViewTitle}">
+             Title="{Binding ViewTitle}"
+             BackgroundColor="#543078"
+             Shell.BackgroundColor="#302059">
     <ContentPage.Resources>
         <conv:InverseBooleanConverter x:Key="InverseBoolean"/>
     </ContentPage.Resources>
@@ -119,6 +121,8 @@
             <Editor  x:Name="Quantity"
                      Text="{Binding Quantity,Mode=TwoWay}"
                      Margin="0,10,0,0"
+                     MaximumHeightRequest="315"
+                     AutoSize="TextChanges"
                      Placeholder="Stärke / Menge - (grob)"
                      MaximumWidthRequest="{Binding Width, Source={x:Reference List}}"
                      FontSize="18"/>
@@ -128,6 +132,8 @@
                      IsVisible="{Binding IsFood}"
                      Text="{Binding PreparationMethod,Mode=TwoWay}"
                      Margin="0,10,0,0"
+                     MaximumHeightRequest="315"
+                     AutoSize="TextChanges"
                      Placeholder="Zubereitungsart (Roh, gekocht, etc.)"
                      MaximumWidthRequest="{Binding Width, Source={x:Reference List}}"
                      FontSize="18"/>

--- a/SymptomTracker/Page/DayPage.xaml
+++ b/SymptomTracker/Page/DayPage.xaml
@@ -4,7 +4,9 @@
                        xmlns:dg="clr-namespace:Maui.DataGrid;assembly=Maui.DataGrid"
                        xmlns:Pages="clr-namespace:SymptomTracker.Page"
                        x:Class="SymptomTracker.Page.DayPage"
-                       Title="{Binding ViewTitle}">
+                       Title="{Binding ViewTitle}"
+                       BackgroundColor="#543078"
+                       Shell.BackgroundColor="#302059">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="50"/>

--- a/SymptomTracker/Page/LoginPage.xaml
+++ b/SymptomTracker/Page/LoginPage.xaml
@@ -3,7 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:converter="clr-namespace:SymptomTracker.Converter"
              x:Class="SymptomTracker.LoginPage"
-             Title="{Binding ViewTitle}">
+             Title="{Binding ViewTitle}"
+             BackgroundColor="#543078"
+             Shell.BackgroundColor="#302059">
 
     <ContentPage.Resources>
         <ResourceDictionary>

--- a/SymptomTracker/Page/MainPage.xaml
+++ b/SymptomTracker/Page/MainPage.xaml
@@ -3,7 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:VM="clr-namespace:SymptomTracker.ViewModel"
              x:Class="SymptomTracker.MainPage"
-             Title="{Binding ViewTitle}">
+             Title="{Binding ViewTitle}"
+             BackgroundColor="#543078"
+             Shell.BackgroundColor="#302059">
     <ContentPage.BindingContext>
         <VM:MainViewModel/>
     </ContentPage.BindingContext>

--- a/SymptomTracker/Page/SettingPage.xaml
+++ b/SymptomTracker/Page/SettingPage.xaml
@@ -2,7 +2,9 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="SymptomTracker.Page.SettingPage"
-             Title="{Binding ViewTitle}">
+             Title="{Binding ViewTitle}"
+             BackgroundColor="#543078"
+             Shell.BackgroundColor="#302059">
     <Grid>
         <VerticalStackLayout
             x:Name="SettingsRoot"

--- a/SymptomTracker/ViewModel/CreateEventViewModel.cs
+++ b/SymptomTracker/ViewModel/CreateEventViewModel.cs
@@ -47,9 +47,9 @@ namespace SymptomTracker.ViewModel
             Date = DateTime.Now;
             Title = String.Empty;
             m_EventType = eventType;
-            Description = " ";
             EndTime = DateTime.Now.TimeOfDay;
             StartTime = DateTime.Now.TimeOfDay;
+
 
             __Ini();
         }


### PR DESCRIPTION
- add colors to the pages
- change the height of the editors that were very big (automatically resize)
- delete initialization of description, because it override the placeholder